### PR TITLE
Increase generated password size

### DIFF
--- a/dokuwiki-recover.php
+++ b/dokuwiki-recover.php
@@ -1102,7 +1102,7 @@ class Recover
     {
         // random new user/password, not cryptographically sound, but good enough for temporary
         $user = 'recover-' . substr(md5(mt_rand() . time()), 0, 6);
-        $pass = substr(md5(mt_rand() . time()), 0, 8);
+        $pass = substr(md5(mt_rand() . time()), 0, 14);
         $hash = sha1($pass);
 
         $newline = "\n$user:$hash:DokuWiki Recovery User. Delete after use:$user@example.com:dokuwiki-recover\n";


### PR DESCRIPTION
8 characters for a password is pretty short, especially considering they are only the characters that come from MD5. I've created this PR as a simple way to make that a bit better and increase the difficulty of brute forcing or cracking the generated password.

If the admin follows directions - they will delete this user. I suspect that doesn't always happen.